### PR TITLE
isRecordLinkElement validation added to use ARRAY_OPERATORS

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -561,7 +561,7 @@ export function availableOperatorsForColumn(column) {
       operators.push.apply(operators, TEXTUAL_OPERATORS);
     }
 
-    if (element.isClassificationElement) {
+    if (element.isClassificationElement || element.isRecordLinkElement) {
       operators.push.apply(operators, ARRAY_OPERATORS);
     }
 


### PR DESCRIPTION
This fix is related to https://github.com/fulcrumapp/fulcrum/issues/3503 in the Fulcrum due to a Postgres description saying: `Array value must start with "{" or dimension information` this only when the query involves `isRecordLinkElement` and found it was missing. Now added with an || operator.