### PR TITLE
Fix error missing FROM-clause entry for table

### DIFF
--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -385,17 +385,17 @@ export default class Converter {
 
   targetList(query, sort, boundingBox) {
     const list = [
-      ResTarget(ColumnRef(AStar()))
+      ResTarget(ColumnRef(AStar(), 'records'))
     ];
 
     const subJoinColumns = query.joinColumnsWithSorting;
 
     if (subJoinColumns.indexOf(query.schema.createdByColumn) !== -1) {
-      list.push(ResTarget(ColumnRef('name', 'created_by'), 'created_by.name'));
+      list.push(ResTarget(ColumnRef('name', query.schema.createdByColumn.join.alias), query.schema.createdByColumn.id));
     }
 
     if (subJoinColumns.indexOf(query.schema.updatedByColumn) !== -1) {
-      list.push(ResTarget(ColumnRef('name', 'updated_by'), 'updated_by.name'));
+      list.push(ResTarget(ColumnRef('name', query.schema.updatedByColumn.join.alias), query.schema.updatedByColumn.id));
     }
 
     if (subJoinColumns.indexOf(query.schema.assignedToColumn) !== -1) {

--- a/src/query.js
+++ b/src/query.js
@@ -321,15 +321,9 @@ export default class Query {
         }
 
         let columnAlias = column.columnName;
-        let columnSort = false;
 
         if (column.join) {
-          columnSort = this.sortColumnExists(column.join.alias)
           columnAlias = [column.join.alias, column.columnName].join('_');
-        }
-
-        if (columnSort) {
-          return ResTarget(ColumnRef(`${column.join.alias}.name`), columnAlias);
         }
 
         return ResTarget(ColumnRef(column.columnName, column.source || 'records'), columnAlias);
@@ -469,11 +463,6 @@ export default class Query {
     ];
   }
 
-  sortColumnExists(columnName) {
-    let expression = this.sorting.expressions.find(sort => sort.field == `${columnName}.name`)
-    return expression ? true : false
-  }
-
   fromClause({applySort, pageSize, pageIndex, boundingBox, searchFilter}) {
     const ast = applySort ? this.toRawAST({sort: this.sortClause, pageSize, pageIndex, boundingBox, searchFilter})
                           : this.toRawAST({boundingBox, searchFilter});
@@ -486,21 +475,20 @@ export default class Query {
 
     // The "subJoinColumns" are joins that need to happen in the inner sub-select from Converter.
     // We don't need to join them in the outer part.
-    const subJoinColumns = this.joinColumnsWithSorting;
 
-    if (this.schema.createdByColumn && subJoinColumns.indexOf(this.schema.createdByColumn) === -1) {
+    if (this.schema.createdByColumn) {
       baseQuery = Converter.joinClause(baseQuery, this.schema.createdByColumn.join);
     }
 
-    if (this.schema.updatedByColumn && subJoinColumns.indexOf(this.schema.updatedByColumn) === -1) {
+    if (this.schema.updatedByColumn) {
       baseQuery = Converter.joinClause(baseQuery, this.schema.updatedByColumn.join);
     }
 
-    if (this.schema.assignedToColumn && subJoinColumns.indexOf(this.schema.assignedToColumn) === -1) {
+    if (this.schema.assignedToColumn) {
       baseQuery = Converter.joinClause(baseQuery, this.schema.assignedToColumn.join);
     }
 
-    if (this.schema.projectColumn && subJoinColumns.indexOf(this.schema.projectColumn) === -1) {
+    if (this.schema.projectColumn) {
       baseQuery = Converter.joinClause(baseQuery, this.schema.projectColumn.join);
     }
 

--- a/src/query.js
+++ b/src/query.js
@@ -321,9 +321,15 @@ export default class Query {
         }
 
         let columnAlias = column.columnName;
+        let columnSort = false;
 
         if (column.join) {
+          columnSort = this.sortColumnExists(column.join.alias)
           columnAlias = [column.join.alias, column.columnName].join('_');
+        }
+
+        if (columnSort) {
+          return ResTarget(ColumnRef(`${column.join.alias}.name`), columnAlias);
         }
 
         return ResTarget(ColumnRef(column.columnName, column.source || 'records'), columnAlias);
@@ -461,6 +467,11 @@ export default class Query {
       ResTarget(ColumnRef('_updated_horizontal_accuracy'), 'updated_horizontal_accuracy'),
       ...joinedColumns
     ];
+  }
+
+  sortColumnExists(columnName) {
+    let expression = this.sorting.expressions.find(sort => sort.field == `${columnName}.name`)
+    return expression ? true : false
   }
 
   fromClause({applySort, pageSize, pageIndex, boundingBox, searchFilter}) {


### PR DESCRIPTION
# What?

There is currently an error when generating the url of a shared_view by filtering through the 'created_by' and 'updated_by' columns

![Screen Shot 2020-07-09 at 1 23 13 AM](https://user-images.githubusercontent.com/10254596/87004275-c9933b00-c182-11ea-9d6a-de30fb09c9ca.png)


Issue  # 4102

# Why?

Because the data is not returned correctly and these filters are frequently used.

# How?

Added a function to determine if the column it is filtered by needs to be put with the correct syntax, thus allowing to execute the SQL statement

# Testing

This was tested from the query API manually, as well as with the fulcrum editor. The data is returned correctly and the statement created is as expected.