### PR TITLE
Update version as a version 1.1.0 had already been published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fulcrum-query-sql",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fulcrum Query SQL Utilities",
   "homepage": "http://github.com/fulcrumapp/fulcrum-query-sql",
   "main": "dist/index.js",


### PR DESCRIPTION
Version `1.1.0` had already been published (but not tagged in github). I just tagged and published `1.1.1`, this brings the version in github back into sync with what's on npm