### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ yarn build
 ```
 
 ### Publishing
+Reach out to your local engineering manager for this step.
 
 - `yarn clean && yarn build`
 - Bump package.json version
 - Merge to `main`
 - Checkout `main`, `git pull`
-- `git tag -a vx.x.x -m "x.x.x"`
+- `git tag -a vx.x.x -m "x.x.x"` (use actual tag number of next release)
 - `git push origin --tags`
-- Create vx.x.x release for tag in github
-- Move .npmrc off to fulcrum.npmrc and `npm login` (Username: fulcrumapp, Password: 1password, Email: support@fulcrumapp.com)
+- Create a release for the tag in github
+- Move .npmrc off to fulcrum.npmrc and `npm login` (Credentials in 1password)
 - `npm publish`
 - Move fulcrum.npmrc back to .npmrc to reset back to your own configurations
 


### PR DESCRIPTION
### **User description**
These credentials are available to engineering management only now, which is not clear in this readme.


___

### **PR Type**
Documentation


___

### **Description**
- Added a note to contact the local engineering manager for the publishing step.
- Clarified the use of actual tag numbers when creating git tags.
- Updated the process for creating a release in GitHub.
- Specified that npm login credentials are stored in 1password.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify publishing instructions and credential management</code></dd></summary>
<hr>

README.md

<li>Added instruction to contact local engineering manager for publishing.<br> <li> Clarified the use of actual tag numbers in git tagging.<br> <li> Updated instructions for creating a release in GitHub.<br> <li> Specified that credentials are stored in 1password.<br>


</details>


  </td>
  <td><a href="https://github.com/fulcrumapp/fulcrum-query-sql/pull/77/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

