### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/dist/ast/converter.js
+++ b/dist/ast/converter.js
@@ -783,7 +783,7 @@ class Converter {
         return (0, helpers_1.AExpr)(0, '&&', (0, helpers_1.ColumnRef)(columnName), rhs);
     }
     escapeLikePercent(value) {
-        return value.replace(/\%/g, '\\%').replace(/_/g, '\\_%');
+        return value.replace(/\\/g, '\\\\').replace(/\%/g, '\\%').replace(/_/g, '\\_%');
     }
     searchFilter(query, search) {
         /*

--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -709,7 +709,7 @@ export default class Converter {
   }
 
   escapeLikePercent(value) {
-    return value.replace(/\%/g, '\\%').replace(/_/g, '\\_%');
+    return value.replace(/\\/g, '\\\\').replace(/\%/g, '\\%').replace(/_/g, '\\_%');
   }
 
   searchFilter(query, search) {


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [Initial critical + high codeql](https://github.com/orgs/fulcrumapp/security/campaigns/4) security campaign:
- https://github.com/fulcrumapp/fulcrum-query-sql/security/code-scanning/2
To fix the problem, we need to ensure that backslashes are also escaped in the `escapeLikePercent` function. This can be done by adding a replacement for backslashes before replacing the percent and underscore characters. We will use a regular expression with the global flag to ensure all occurrences are replaced.
  


- https://github.com/fulcrumapp/fulcrum-query-sql/security/code-scanning/1
To fix the problem, we need to ensure that backslashes in the input string are properly escaped before escaping other characters. This can be done by first replacing all backslashes with double backslashes, and then proceeding with the existing replacements for `%` and `_`. This ensures that any backslashes in the input are correctly handled.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
