### PR TITLE
[bug/FLCRM-20154] select specific values bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/query-sql",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Fulcrum Query SQL Utilities",
   "homepage": "http://github.com/fulcrumapp/fulcrum-query-sql",
   "type": "module",

--- a/src/ast/__tests__/converter.test.js
+++ b/src/ast/__tests__/converter.test.js
@@ -903,11 +903,11 @@ describe('toDistinctValuesAST limit', () => {
     query = new Query({ form, schema });
   });
 
-  it('applies the default limit of 10000 when no limit is specified', () => {
+  it('applies the default limit of 1000 when no limit is specified', () => {
     const column = schema.columns.find(c => c.id === '3bd0');
     const sql = query.toDistinctValuesSQL({ column, by: 'frequency' });
 
-    expect(sql).toContain('LIMIT 10000');
+    expect(sql).toContain('LIMIT 1000');
   });
 
   it('applies a custom limit when options.limit is specified', () => {
@@ -924,11 +924,11 @@ describe('toDistinctValuesAST limit', () => {
     expect(sql).toContain('LIMIT 10000');
   });
 
-  it('does not include the old 1000 hard limit', () => {
+  it('applies the default hard limit of 1000', () => {
     const column = schema.columns.find(c => c.id === '3bd0');
     const sql = query.toDistinctValuesSQL({ column, by: 'frequency' });
 
-    expect(sql).not.toContain('LIMIT 1000');
+    expect(sql).toMatch(/\bLIMIT 1000\b/);
   });
 
   it('treats options.limit of 0 as explicit zero (not falling back to default)', () => {
@@ -937,6 +937,6 @@ describe('toDistinctValuesAST limit', () => {
 
     // 0 is falsy but != null, so it uses 0 explicitly rather than falling back to MAX_DISTINCT_VALUES
     expect(sql).toContain('LIMIT 0');
-    expect(sql).not.toContain('LIMIT 10000');
+    expect(sql).not.toContain('LIMIT 1000');
   });
 });

--- a/src/ast/__tests__/converter.test.js
+++ b/src/ast/__tests__/converter.test.js
@@ -862,3 +862,81 @@ describe('gps_device_capture column', () => {
     });
   });
 });
+
+describe('toDistinctValuesAST limit', () => {
+  const formJson = {
+    id: '7a62278f-4eb8-480c-8f0c-34fc79d28bee',
+    name: 'TestForm',
+    status_field: {
+      type: 'StatusField',
+      label: 'Status',
+      data_name: 'status',
+    },
+    elements: [
+      {
+        type: 'TextField',
+        key: '3bd0',
+        label: 'Text',
+        data_name: 'text',
+      },
+    ],
+  };
+
+  const rawColumns = {
+    form: [
+      {
+        field: '3bd0',
+        name: 'text',
+        type: 'string',
+      },
+    ],
+    repeatables: {},
+  };
+
+  let form;
+  let schema;
+  let query;
+
+  beforeEach(() => {
+    form = new Form(formJson);
+    schema = new FormSchema(form, rawColumns.form, rawColumns.repeatables, { fullSchema: true });
+    query = new Query({ form, schema });
+  });
+
+  it('applies the default limit of 10000 when no limit is specified', () => {
+    const column = schema.columns.find(c => c.id === '3bd0');
+    const sql = query.toDistinctValuesSQL({ column, by: 'frequency' });
+
+    expect(sql).toContain('LIMIT 10000');
+  });
+
+  it('applies a custom limit when options.limit is specified', () => {
+    const column = schema.columns.find(c => c.id === '3bd0');
+    const sql = query.toDistinctValuesSQL({ column, by: 'frequency', limit: 500 });
+
+    expect(sql).toContain('LIMIT 500');
+  });
+
+  it('applies a custom limit of 10000 when options.limit is explicitly 10000', () => {
+    const column = schema.columns.find(c => c.id === '3bd0');
+    const sql = query.toDistinctValuesSQL({ column, by: 'frequency', limit: 10000 });
+
+    expect(sql).toContain('LIMIT 10000');
+  });
+
+  it('does not include the old 1000 hard limit', () => {
+    const column = schema.columns.find(c => c.id === '3bd0');
+    const sql = query.toDistinctValuesSQL({ column, by: 'frequency' });
+
+    expect(sql).not.toContain('LIMIT 1000');
+  });
+
+  it('treats options.limit of 0 as explicit zero (not falling back to default)', () => {
+    const column = schema.columns.find(c => c.id === '3bd0');
+    const sql = query.toDistinctValuesSQL({ column, by: 'frequency', limit: 0 });
+
+    // 0 is falsy but != null, so it uses 0 explicitly rather than falling back to MAX_DISTINCT_VALUES
+    expect(sql).toContain('LIMIT 0');
+    expect(sql).not.toContain('LIMIT 10000');
+  });
+});

--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -32,7 +32,7 @@ import { ConditionType } from '../condition.js';
 import { OperatorType, calculateDateRange } from '../operator.js';
 import { AggregateType } from '../aggregate.js';
 
-const MAX_DISTINCT_VALUES = 10000;
+const MAX_DISTINCT_VALUES = 1000;
 const MAX_TILE_RECORDS = 1000;
 
 const columnRef = (column) => {

--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -32,7 +32,7 @@ import { ConditionType } from '../condition.js';
 import { OperatorType, calculateDateRange } from '../operator.js';
 import { AggregateType } from '../aggregate.js';
 
-const MAX_DISTINCT_VALUES = 1000;
+const MAX_DISTINCT_VALUES = 10000;
 const MAX_TILE_RECORDS = 1000;
 
 const columnRef = (column) => {
@@ -296,7 +296,7 @@ export default class Converter {
 
     sortClause.push(SortBy(AConst(IntegerValue(1)), 1, 0));
 
-    const limitCount = this.limitCount(MAX_DISTINCT_VALUES);
+    const limitCount = this.limitCount(options.limit != null ? options.limit : MAX_DISTINCT_VALUES);
 
     return SelectStmt({targetList, fromClause, whereClause, groupClause, sortClause, limitCount});
   }

--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -296,7 +296,8 @@ export default class Converter {
 
     sortClause.push(SortBy(AConst(IntegerValue(1)), 1, 0));
 
-    const limitCount = this.limitCount(options.limit != null ? options.limit : MAX_DISTINCT_VALUES);
+    const limit = options.limit != null ? Math.trunc(+options.limit) : MAX_DISTINCT_VALUES;
+    const limitCount = this.limitCount(Number.isFinite(limit) && limit >= 0 ? limit : MAX_DISTINCT_VALUES);
 
     return SelectStmt({targetList, fromClause, whereClause, groupClause, sortClause, limitCount});
   }


### PR DESCRIPTION
Previously, the distinct values query used a hardcoded limit of 1,000 results. This caused issues when users needed to select from fields with more than 1,000 unique values — options were silently truncated.

Changes:

Doesn't raise the default MAX_DISTINCT_VALUES cap from 1,000 → 10,000, leaves it alone
Made the limit overridable via options.limit so callers can pass a custom cap when needed
Added test coverage for the new configurable limit behavior

Testing:

Unit tests added in src/ast/__tests__/converter.test.js covering the default and custom limit cases