### PR TITLE
Fix fulcrum-core import interop for ESM/CJS consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/query-sql",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Fulcrum Query SQL Utilities",
   "homepage": "http://github.com/fulcrumapp/fulcrum-query-sql",
   "type": "module",

--- a/src/schema/__tests__/element-column.test.js
+++ b/src/schema/__tests__/element-column.test.js
@@ -1,5 +1,8 @@
-import { Record, StatusValue } from '@fulcrumapp/fulcrum-core';
+import * as fulcrumCoreNamespace from '@fulcrumapp/fulcrum-core';
 import ElementColumn from '../element-column.js';
+
+const fulcrumCore = fulcrumCoreNamespace.default ?? fulcrumCoreNamespace;
+const { Record, StatusValue } = fulcrumCore;
 
 describe('ElementColumn status handling', () => {
   const statusElement = {

--- a/src/schema/__tests__/element-column.test.js
+++ b/src/schema/__tests__/element-column.test.js
@@ -1,0 +1,32 @@
+import { Record, StatusValue } from '@fulcrumapp/fulcrum-core';
+import ElementColumn from '../element-column.js';
+
+describe('ElementColumn status handling', () => {
+  const statusElement = {
+    key: 'status_key',
+    label: 'Status',
+    dataName: 'status',
+    isStatusElement: true,
+  };
+
+  it('returns the statusValue for Record instances', () => {
+    const feature = Object.create(Record.prototype);
+    Object.defineProperty(feature, 'statusValue', {
+      value: 'record-status-value',
+      configurable: true,
+    });
+
+    const column = new ElementColumn({ element: statusElement });
+
+    expect(column.valueFrom(feature)).toBe('record-status-value');
+  });
+
+  it('creates a StatusValue for non-Record features', () => {
+    const feature = { recordStatus: 'open' };
+    const column = new ElementColumn({ element: statusElement });
+
+    const value = column.valueFrom(feature);
+
+    expect(value).toBeInstanceOf(StatusValue);
+  });
+});

--- a/src/schema/element-column.js
+++ b/src/schema/element-column.js
@@ -1,5 +1,7 @@
-import { StatusValue, Record } from '@fulcrumapp/fulcrum-core';
+import fulcrumCore from '@fulcrumapp/fulcrum-core';
 import Column from './column.js';
+
+const { StatusValue, Record } = fulcrumCore;
 
 export default class ElementColumn extends Column {
   constructor({

--- a/src/schema/element-column.js
+++ b/src/schema/element-column.js
@@ -1,6 +1,7 @@
-import fulcrumCore from '@fulcrumapp/fulcrum-core';
+import * as fulcrumCoreNamespace from '@fulcrumapp/fulcrum-core';
 import Column from './column.js';
 
+const fulcrumCore = fulcrumCoreNamespace.default ?? fulcrumCoreNamespace;
 const { StatusValue, Record } = fulcrumCore;
 
 export default class ElementColumn extends Column {


### PR DESCRIPTION
This change updates how fulcrum-query-sql imports Record and StatusValue from @fulcrumapp/fulcrum-core to avoid runtime interop issues in mixed module environments.

# Why

data-exports consumes fulcrum-query-sql in an ESM/NodeNext path, while fulcrum-core export shape can vary across ESM/CJS boundaries. Direct named imports are not consistently reliable in that setup.

# What changed

Import fulcrum-core as a module object.
Read Record and StatusValue from that object.
Keep behavior unchanged for status value handling.

# Impact

Named imports are strict about export shape; default-import-then-destructure is more tolerant in mixed ESM/CJS ecosystems.
No functional query behavior change.

# Validation

Existing tests pass.
Added/updated status handling coverage in element-column tests to confirm Record and StatusValue behavior remains correct.


1. ESM app importing a CJS-shaped package
Before (can throw at import time if package does not expose real named exports):
import { Record, StatusValue } from '@fulcrumapp/fulcrum-core';

Possible error:
SyntaxError: The requested module '@fulcrumapp/fulcrum-core' does not provide an export named 'Record'

Now (safer):
```
import fulcrumCore from '@fulcrumapp/fulcrum-core';
const { Record, StatusValue } = fulcrumCore;
```

Why it works:
Node can map CJS module.exports into default, then you pull fields from that object.

Mixed toolchains (NodeNext app + legacy/transpiled dependency)
Before:
```
import { Record } from '@fulcrumapp/fulcrum-core';
```

Risk:
Build/runtime mismatch on whether named exports are synthesized.

Now:
```
import fulcrumCore from '@fulcrumapp/fulcrum-core';
const { Record } = fulcrumCore;
```

Result:
Less dependent on tool-specific named export synthesis behavior.

Runtime path in your actual status handling logic
Before (if named import failed, this path never runs):
```
if (feature instanceof Record) {
return feature.statusValue;
}
return new StatusValue(this.element, feature.recordStatus);
```

Failure mode:
Record or StatusValue import may fail before code executes.

Now:
```
import fulcrumCore from '@fulcrumapp/fulcrum-core';
const { Record, StatusValue } = fulcrumCore;
```

Result:
Same behavior, but dependencies resolve more reliably across ESM/CJS boundaries.

Consumer variety (Jest, local scripts, app runtime)
Before:
Some environments pass, others fail depending on module loader behavior.

Now:
All environments that can default-import the package object behave consistently, because the destructuring happens from one resolved object shape.
