### PR TITLE
the gps device column is optional

### DIFF
--- a/src/ast/__tests__/converter.test.js
+++ b/src/ast/__tests__/converter.test.js
@@ -712,6 +712,11 @@ describe('gps_device_capture column', () => {
     repeatables: {},
   };
 
+  const rawColumnsWithoutGPSDeviceCapture = {
+    form: rawColumns.form.filter((column) => column.name !== '_gps_device_capture'),
+    repeatables: {},
+  };
+
   describe('FormSchema', () => {
     it('includes _gps_device_capture in fullSchema columns', () => {
       const form = new Form(formJson);
@@ -740,6 +745,20 @@ describe('gps_device_capture column', () => {
       const sql = query.toSQL({ applySort: false });
 
       expect(sql).toContain('"_gps_device_capture" AS "gps_device_capture"');
+    });
+
+    it('does not include gps_device_capture in the SQL target list when rawColumns omits it', () => {
+      const form = new Form(formJson);
+      const schema = new FormSchema(
+        form,
+        rawColumnsWithoutGPSDeviceCapture.form,
+        rawColumnsWithoutGPSDeviceCapture.repeatables,
+        { fullSchema: true },
+      );
+      const query = new Query({ form, schema, full: true });
+      const sql = query.toSQL({ applySort: false });
+
+      expect(sql).not.toContain('"_gps_device_capture" AS "gps_device_capture"');
     });
   });
 

--- a/src/form-field-schema.js
+++ b/src/form-field-schema.js
@@ -87,6 +87,10 @@ export default class FormFieldSchema {
     return this.columns.find(e => e.id === id);
   }
 
+  hasRawColumn(columnName) {
+    return Object.hasOwn(this._rawColumnsByKey || {}, columnName);
+  }
+
   columnForFieldKey(fieldKey, part) {
     if (part) {
       return this._columnsByKey[`${fieldKey}_${part}`];

--- a/src/form-schema.js
+++ b/src/form-schema.js
@@ -85,10 +85,6 @@ export default class FormSchema extends FormFieldSchema {
     return Object.values(this._rawColumns).some((item) => item.name === '_record_key');
   }
 
-  hasRawColumn(columnName) {
-    return Object.hasOwn(this._rawColumnsByKey, columnName);
-  }
-
   get hasRecordSeriesID() { // TODO: Remove once all forms have been upgraded to v4
     return Object.keys(this._rawColumnsByKey).includes('_record_series_id');
   }

--- a/src/form-schema.js
+++ b/src/form-schema.js
@@ -85,6 +85,10 @@ export default class FormSchema extends FormFieldSchema {
     return Object.values(this._rawColumns).some((item) => item.name === '_record_key');
   }
 
+  hasRawColumn(columnName) {
+    return Object.hasOwn(this._rawColumnsByKey, columnName);
+  }
+
   get hasRecordSeriesID() { // TODO: Remove once all forms have been upgraded to v4
     return Object.keys(this._rawColumnsByKey).includes('_record_series_id');
   }
@@ -176,9 +180,11 @@ export default class FormSchema extends FormFieldSchema {
       this.addSystemColumn('Accuracy', 'horizontalAccuracy', '_horizontal_accuracy', 'double');
       this.addSystemColumn('Changeset', 'changesetID', '_changeset_id', 'string');
 
-      // JSONB in Postgres but typed as 'string' here — no jsonb type exists in this schema system.
-      // Only Empty/NotEmpty operators are allowed (see MEDIA_OPERATORS in operator.js).
-      this.addSystemColumn('GPS Device Capture', 'gpsDeviceCapture', '_gps_device_capture', 'string');
+      if (this.hasRawColumn('_gps_device_capture')) {
+        // JSONB in Postgres but typed as 'string' here - no jsonb type exists in this schema system.
+        // Only Empty/NotEmpty operators are allowed (see MEDIA_OPERATORS in operator.js).
+        this.addSystemColumn('GPS Device Capture', 'gpsDeviceCapture', '_gps_device_capture', 'string');
+      }
 
       this.addSystemColumn('Created Duration', 'createdDuration', '_created_duration', 'integer');
       this.addSystemColumn('Updated Duration', 'updatedDuration', '_updated_duration', 'integer');

--- a/src/query.js
+++ b/src/query.js
@@ -389,6 +389,11 @@ export default class Query {
         joinedColumns.push(ResTarget(ColumnRef(`${alias}.name`), alias));
       }
     }
+
+    const gpsDeviceCaptureColumns = this.schema.findColumnByID('_gps_device_capture')
+      ? [ResTarget(ColumnRef('_gps_device_capture'), 'gps_device_capture')]
+      : [];
+
     if (this.schema.recordSeriesColumn) {
       const { alias } = this.schema.recordSeriesColumn.join;
 
@@ -490,7 +495,7 @@ export default class Query {
       ResTarget(ColumnRef('_course'), 'course'),
       ResTarget(ColumnRef('_horizontal_accuracy'), 'horizontal_accuracy'),
       ResTarget(ColumnRef('_vertical_accuracy'), 'vertical_accuracy'),
-      ResTarget(ColumnRef('_gps_device_capture'), 'gps_device_capture'),
+      ...gpsDeviceCaptureColumns,
       ResTarget(ColumnRef('_edited_duration'), 'edited_duration'),
       ResTarget(ColumnRef('_updated_duration'), 'updated_duration'),
       ResTarget(ColumnRef('_created_duration'), 'created_duration'),

--- a/src/query.js
+++ b/src/query.js
@@ -390,7 +390,7 @@ export default class Query {
       }
     }
 
-    const gpsDeviceCaptureColumns = this.schema.findColumnByID('_gps_device_capture')
+    const gpsDeviceCaptureColumns = this.schema.hasRawColumn('_gps_device_capture')
       ? [ResTarget(ColumnRef('_gps_device_capture'), 'gps_device_capture')]
       : [];
 


### PR DESCRIPTION
so we should ignore it if it doesn't exist.

Gates the optional `_gps_device_capture` system column on the raw schema so older DB views that do not expose the column do not generate invalid SQL projections.

Changes

- Added a FormSchema raw-column presence check for `_gps_device_capture`.
- Updated full query projection to include gps_device_capture only when the schema contains that column.
- Added regression coverage for building FormSchema without `_gps_device_capture` and verifying `toSQL()` does not select it.


Tested in exporter with the latest fulcrumapp/query-sql