### PR TITLE
Fix equal-bound histogram queries

### DIFF
--- a/src/__tests__/histogram.test.js
+++ b/src/__tests__/histogram.test.js
@@ -1,0 +1,46 @@
+import { Form } from '@fulcrumapp/fulcrum-core';
+import FormSchema from '../form-schema.js';
+import Query from '../query.js';
+
+const form = new Form({
+  id: 'histogram-form',
+  elements: [
+    {
+      type: 'TextField',
+      key: 'number',
+      data_name: 'number',
+      numeric: true,
+    },
+    {
+      type: 'DateTimeField',
+      key: 'date',
+      data_name: 'date',
+    },
+  ],
+});
+
+const schema = new FormSchema(form, [
+  { field: 'number', name: 'number', type: 'double' },
+  { field: 'date', name: 'date', type: 'timestamp' },
+  { name: '_server_updated_at', type: 'timestamp' },
+], {}, { fullSchema: false });
+
+describe('Query.toHistogramSQL', () => {
+  it.each([
+    ['numeric', 'number', 'number'],
+    ['date', 'date', 'date'],
+  ])('uses a valid upper bound for identical %s values', (_label, field, type) => {
+    const column = schema.columnForFieldKey(field);
+    const query = new Query({ form, schema, full: true });
+
+    const sql = query.toHistogramSQL({
+      column,
+      bucketSize: 63,
+      type,
+    });
+
+    expect(sql).toMatch(
+      /width_bucket\([\s\S]*COALESCE\(nullif\("max_value", "min_value"\), \(\("min_value"\) \+ \(1\)\)\)/,
+    );
+  });
+});

--- a/src/ast/converter.js
+++ b/src/ast/converter.js
@@ -192,10 +192,21 @@ export default class Converter {
     const seriesFunctionCall = FuncCall('generate_series', seriesFunctionArgs);
     const seriesFunction = RangeFunction([[seriesFunctionCall]], Alias('series'));
 
+    const upperBoundSubquery = SubLink(4, SelectStmt({
+      targetList: [ResTarget(CoalesceExpr([
+        FuncCall('nullif', [
+          ColumnRef('max_value'),
+          ColumnRef('min_value'),
+        ]),
+        AExpr(0, '+', ColumnRef('min_value'), AConst(IntegerValue(1))),
+      ]))],
+      fromClause: [RangeVar('__stats')],
+    }));
+
     const bucketWidthFunctionCallArgs = [
       TypeCast(TypeName([StringValue('pg_catalog'), StringValue('float8')]), ColumnRef('value')),
       SubLink(4, SelectStmt({ targetList: [ResTarget(ColumnRef('min_value'))], fromClause: [RangeVar('__stats')] })),
-      SubLink(4, SelectStmt({ targetList: [ResTarget(ColumnRef('max_value'))], fromClause: [RangeVar('__stats')] })),
+      upperBoundSubquery,
       SubLink(4, SelectStmt({ targetList: [ResTarget(ColumnRef('buckets'))], fromClause: [RangeVar('__stats')] })),
     ];
 


### PR DESCRIPTION
## What\n\n- Guard histogram upper bounds when a filtered result set has one distinct numeric or date value.\n- Add numeric and date SQL-generation regression coverage.\n\n## Why\n\nPostgreSQL rejects width_bucket queries when the lower and upper bounds are equal, breaking DataView range filters for single-value result sets.\n\n## Testing\n\n- yarn test\n- yarn typecheck\n- yarn build\n- Executed generated numeric and date histogram SQL against PostgreSQL for one-value and normal-range datasets.